### PR TITLE
AddressSanitizer fixes

### DIFF
--- a/RSDKv4/NativeObjects/PlayerSelectScreen.cpp
+++ b/RSDKv4/NativeObjects/PlayerSelectScreen.cpp
@@ -226,13 +226,14 @@ void PlayerSelectScreen_Main(void *objPtr)
                 SetGlobalVariableByName("starPostID", 0);
                 debugMode = false;
 
+                int charID = 0;
                 switch (self->playerID) {
-                    case SAVESEL_SONIC: saveGame->files[saveSel->selectedButton - 1].characterID = 0; break;
-                    case SAVESEL_TAILS: saveGame->files[saveSel->selectedButton - 1].characterID = 1; break;
-                    case SAVESEL_KNUX: saveGame->files[saveSel->selectedButton - 1].characterID = 2; break;
-                    case SAVESEL_ST: saveGame->files[saveSel->selectedButton - 1].characterID = 3; break;
+                    case SAVESEL_SONIC: charID = 0; break;
+                    case SAVESEL_TAILS: charID = 1; break;
+                    case SAVESEL_KNUX: charID = 2; break;
+                    case SAVESEL_ST: charID = 3; break;
                 }
-                InitStartingStage(STAGELIST_PRESENTATION, 0, saveGame->files[saveSel->selectedButton - 1].characterID);
+                InitStartingStage(STAGELIST_PRESENTATION, 0, charID);
 
                 CREATE_ENTITY(FadeScreen);
             }

--- a/RSDKv4/Object.cpp
+++ b/RSDKv4/Object.cpp
@@ -477,7 +477,7 @@ void RemoveNativeObject(NativeEntityBase *entity)
 #if !RETRO_USE_ORIGINAL_CODE
     if (!entity)
         return;
-    memcpy(&activeEntityList[entity->objectID], &activeEntityList[entity->objectID + 1], sizeof(int) * (NATIVEENTITY_COUNT - (entity->objectID + 2)));
+    memmove(&activeEntityList[entity->objectID], &activeEntityList[entity->objectID + 1], sizeof(int) * (NATIVEENTITY_COUNT - (entity->objectID + 2)));
     --nativeEntityCount;
     for (int i = entity->slotID; objectEntityBank[i].eventMain; ++i) objectEntityBank[i].objectID--;
 #else


### PR DESCRIPTION
**- RemoveNativeObject: Fix memcpy overlap**
Both src and dst pointers overlap, so memcpy is unsafe here.
Use memmove instead.

**- PlayerSelectScreen: Fix invalid SaveRAM access in no-save mode**
In no-save mode, this code was trying to access `saveGame->files[-1]`.
No-save doesn't write anything to SaveRAM in the original code, and
save mode already wrote it, so all we need is to get the charID.