### PR TITLE
Remove `RETRO_FORCE_CASE_SENSITIVE` check in `Windows.cmake`

### DIFF
--- a/platforms/Windows.cmake
+++ b/platforms/Windows.cmake
@@ -4,12 +4,6 @@ add_executable(RetroEngine ${RETRO_FILES})
 
 set(DEP_PATH windows)
 
-if(RETRO_FORCE_CASE_SENSITIVE)
-    add_executable(RetroEngine ${RETRO_FILES}
-        RSDKv3/fcaseopen.c
-    )
-endif()
-
 find_package(Ogg CONFIG)
 
 if(NOT ${Ogg_FOUND})


### PR DESCRIPTION
The file that is added to it is already listed in the `CMakeLists.txt` file. 
Plus, had the check been corrected from `RETRO_FORCE_CASE_SENSITIVE` to `RETRO_FORCE_CASE_INSENSITIVE`, it would still not work correctly due to it getting the needed file from a nonexistent `RSDKv3` folder rather than the more correct `RSDKv4` folder.